### PR TITLE
Add support for inline link buttons and fix some minor bugs

### DIFF
--- a/telegram_menu/models.py
+++ b/telegram_menu/models.py
@@ -66,6 +66,7 @@ class ButtonType(Enum):
     PICTURE = auto()
     STICKER = auto()
     POLL = auto()
+    LINK = auto()
 
 
 @dataclass
@@ -244,9 +245,14 @@ class BaseMessage(ABC):
             for btn in row:
                 lbl = f"{self.label}.{btn.label}"
                 if btn.web_app_url and validators.url(btn.web_app_url):
-                    button_array.append(
-                        InlineKeyboardButton(text=btn.label, web_app=WebAppInfo(url=btn.web_app_url), callback_data=lbl)
-                    )
+                    if btn.btype == ButtonType.LINK:
+                        button_array.append(
+                            InlineKeyboardButton(text=btn.label, url=btn.web_app_url)
+                        )
+                    else:
+                        button_array.append(
+                            InlineKeyboardButton(text=btn.label, web_app=WebAppInfo(url=btn.web_app_url))  # do not use callback_data as it is not supported
+                        )
                 else:
                     button_array.append(InlineKeyboardButton(text=btn.label, callback_data=lbl))
             keyboard_buttons.append(button_array)

--- a/telegram_menu/models.py
+++ b/telegram_menu/models.py
@@ -246,9 +246,7 @@ class BaseMessage(ABC):
                 lbl = f"{self.label}.{btn.label}"
                 if btn.web_app_url and validators.url(btn.web_app_url):
                     if btn.btype == ButtonType.LINK:
-                        button_array.append(
-                            InlineKeyboardButton(text=btn.label, url=btn.web_app_url)
-                        )
+                        button_array.append(InlineKeyboardButton(text=btn.label, url=btn.web_app_url))
                     else:
                         # do not use callback_data as it is not supported
                         button_array.append(

--- a/telegram_menu/models.py
+++ b/telegram_menu/models.py
@@ -250,8 +250,9 @@ class BaseMessage(ABC):
                             InlineKeyboardButton(text=btn.label, url=btn.web_app_url)
                         )
                     else:
+                        # do not use callback_data as it is not supported
                         button_array.append(
-                            InlineKeyboardButton(text=btn.label, web_app=WebAppInfo(url=btn.web_app_url))  # do not use callback_data as it is not supported
+                            InlineKeyboardButton(text=btn.label, web_app=WebAppInfo(url=btn.web_app_url))
                         )
                 else:
                     button_array.append(InlineKeyboardButton(text=btn.label, callback_data=lbl))


### PR DESCRIPTION
- Use args as a callback argument for non-BaseMessage non-Inline buttons when args is set
- Call text_input method on the last active BaseMessage. That could also be a BaseMessage with Inline Buttons that is not the last sent one
- Add support for inline buttons that open an url using new `ButtonType.LINK` and setting the existing field `web_app_url`
- WebApp can be launched from inline buttons but `callback_data` is NOT supported (read from [here](https://stackoverflow.com/questions/72400465/telegram-launching-web-app-from-inline-button) and personally tested).  Note that setting `callback_data` field for Inline Buttons will prevent the WebApp from launching. Also note that in WebApp launched from inline buttons the javascript method `sendData` won't work (read [here](https://stackoverflow.com/questions/71909144/dont-get-a-response-from-from-telegram-web-app-for-bots) and personally tested)