### PR TITLE
Update commands.sh for pyproject-based build and tooling

### DIFF
--- a/commands.sh
+++ b/commands.sh
@@ -17,15 +17,15 @@ call_pylint()
 call_pystyle()
 {
   echo "### Call pydocstyle"
-  pydocstyle .
+  pydocstyle telegram_menu
   echo "### Call pycodestyle"
-  pycodestyle --max-line-length=120 .
+  pycodestyle --max-line-length=120 telegram_menu
 }
 
 call_mypy()
 {
   echo "### Call Mypy"
-  mypy --config-file mypy.ini .
+  mypy telegram_menu
 }
 
 call_isort()
@@ -93,7 +93,8 @@ call_check()
 
 call_release()
 {
-  python setup.py sdist
-  # python -m twine upload dist/*.tar.gz
+  rm -rf dist
+  python -m build
+  # python -m twine upload dist/*
   # pip install -U --index-url https://pypi.org/simple/ telegram_menu
 }


### PR DESCRIPTION
## Summary
Updates `commands.sh` to match the pyproject-based packaging and tooling introduced in #23.

- **call_release**: replace the removed `python setup.py sdist` with `python -m build` (builds sdist + wheel; twine target widened to `dist/*`)
- **call_mypy**: drop the removed `mypy.ini` reference (mypy config now lives in `pyproject.toml`)
- **call_pystyle**: scope `pydocstyle`/`pycodestyle` to `telegram_menu` so they don't scan local virtualenvs

Verified: `bash -n commands.sh` passes and `python -m build --sdist` produces `dist/telegram_menu-3.0.0.tar.gz`.

Generated with [Claude Code](https://claude.com/claude-code)
